### PR TITLE
Made upgrade module skip RepeatedFunctionCall.py.j2 and not skip .py.j2 files

### DIFF
--- a/update.py
+++ b/update.py
@@ -553,7 +553,7 @@ def _updateNumbers(python):
 
         fullpath = os.path.join(cases_dir, filename)
 
-        if not (filename.endswith(".py") or filename.endswith(".py.j2")):
+        if not (filename.endswith(".py", ".py.j2")):
             continue
         if filename.startswith("run_"):
             continue

--- a/update.py
+++ b/update.py
@@ -548,12 +548,12 @@ def _updateNumbers(python):
     cases_dir = getTestCasesDir()
 
     for filename in sorted(os.listdir(cases_dir)):
-        if filename == "InplaceOperationInstanceStringAdd.py":
+        if filename in ["InplaceOperationInstanceStringAdd.py", "RepeatedFunctionCall.py.j2"]:
             continue
 
         fullpath = os.path.join(cases_dir, filename)
 
-        if not filename.endswith(".py"):
+        if not (filename.endswith(".py") or filename.endswith(".py.j2")):
             continue
         if filename.startswith("run_"):
             continue


### PR DESCRIPTION
The main purpose of this pull request is to enable using .py.j2 files for measuring construct performance while building the site. (If my pull request in Nuitka/Nuitka as merged)